### PR TITLE
Add projects listing and page skeletons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.bundle
+Gemfile.lock
+_site

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+The main site of `image-rs` at <www.image-rs.org>.
+
+## Contributing
+
+Any member of the organization is welcome to contribute to the site, not only
+collaborators. The main branch that is served over `www.image-rs.org` should
+only be changed through PRs with at least one review, regardless of the author.
+Major changes to the structure or look should gather some feedback over a week
+but at least three days (so that one is a work day).
+
+Most pressing issues:
+
+* Design the pages instead of relying on a rather unstructured default look.
+* Establish a system for tags and categories
+* Evaluate how to present the individual projects under the organization. Each
+  projects could have one dedicated maintainer on its project page.
+
+## Serving locally
+
+For basic usage, follow [the official Github guide][GHGuide]. If you are not
+comfortable giving `sudo` to the `bundler` commands just for this project (i.e.
+this is not your main project or you created a project related account to
+confine access, ...) like me then you can also do:
+
+1. Create some local directory used to hold the installed gems. I use
+   `GEM_HOME=~/.local/lib/gems` to mirror the root tree that would otherwise be used.
+2. > `bundle install --path $GEM_HOME`
+3. Invoke jekyll through `bundle` as well
+  > `bundle exec jekyll serve`
+
+
+[GHGuide]: https://help.github.com/en/articles/setting-up-your-github-pages-site-locally-with-jekyll

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,4 @@
 theme: jekyll-theme-slate
+collections:
+        projects:
+                output: true

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 theme: jekyll-theme-slate
 collections:
+        summaries:
         projects:
                 output: true

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,maximum-scale=2">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+
+{% seo %}
+  </head>
+
+  <body>
+
+    <!-- HEADER -->
+    <div id="header_wrap" class="outer">
+        <header class="inner">
+          <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
+
+          <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
+          <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
+
+          {% if site.show_downloads %}
+            <section id="downloads">
+              <a class="zip_download_link" href="{{ site.github.zip_url }}">Download this project as a .zip file</a>
+              <a class="tar_download_link" href="{{ site.github.tar_url }}">Download this project as a tar.gz file</a>
+            </section>
+          {% endif %}
+        </header>
+    </div>
+
+    <!-- MAIN CONTENT -->
+    <div id="main_content_wrap" class="outer">
+      <main id="main_content" class="inner-wide">
+        {{ content }}
+      </main>
+    </div>
+
+    <!-- FOOTER  -->
+    <div id="footer_wrap" class="outer">
+      <footer class="inner">
+        {% if site.github.is_project_page %}
+        <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+        {% endif %}
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+<div>
+<h1 class="post-title">
+	{{ page.title }}
+</h1>
+
+<main class="post-content">
+	{{ content }}
+</main>
+</div>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -3,6 +3,22 @@ layout: default
 ---
 
 <div>
+<nav class="external-sites">
+  {% if page.github %}
+  <p><a href="{{ page.github }}">Repository</a></p>
+  {% endif %}
+  {% if page.crates_io %}
+  <p><a href="{{ page.crates_io }}" rel=external>
+    <img alt="Crates.io" src="{{ page.crates_io_badge }}" style="max-width: 100%;"/>
+  </a></p>
+  {% endif %}
+  {% if page.docs %}
+  <p><a href="{{ page.docs }}" rel=external>
+    <img alt="Documentation" src="{{ page.docs_badge }}" style="max-width: 100%;"/>
+  </a></p>
+  {% endif %}
+</nav>
+
 <h1 class="post-title">
 	{{ page.title }}
 </h1>

--- a/_projects/image.md
+++ b/_projects/image.md
@@ -1,6 +1,12 @@
 ---
 layout: project
 name: "image"
+weight: 1000
+crates_io: "https://crates.io/crates/image"
+crates_io_badge: "https://img.shields.io/crates/v/image.svg"
+github: "https://github.com/image-rs/image"
+docs: "https://docs.rs/image"
+docs_badge: "https://docs.rs/image/badge.svg"
 ---
 
 The `image` project.

--- a/_projects/image.md
+++ b/_projects/image.md
@@ -1,0 +1,6 @@
+---
+layout: project
+name: "image"
+---
+
+The `image` project.

--- a/_summaries/image.md
+++ b/_summaries/image.md
@@ -1,0 +1,6 @@
+---
+name: "image"
+---
+
+Aggregates major image formats into a coherent interface for reading, writing
+and editing.

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -49,3 +49,13 @@ a:hover {
     max-width: 100%;
   }
 }
+
+.external-sites {
+  float: right;
+}
+
+.external-sites>p {
+  margin-top: 1px;
+  margin-bottom: 1px;
+  padding: unset;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,51 @@
+---
+---
+
+@import "jekyll-theme-slate";
+
+.inner-wide { 
+  position: relative;
+  max-width: 992px;
+  padding: 20px 10px;
+  margin: 0 auto;
+}
+
+.image-rs-inline-avatar {
+  display: inline;
+  margin: 0px;
+  height: 1em;
+  vertical-align: text-bottom;
+}
+
+.post-info {
+  text-align: right;
+  font-weight: bold;
+}
+
+.subtle-link {
+  color: inherit;
+}
+
+a:hover {
+  color: #0F79D0;
+  text-decoration: none;
+}
+
+.project-list {
+  display: flex;
+  max-width: 300ch;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.project-list > article {
+  width: 45%;
+  max-width: 45%;
+  box-sizing: border-box;
+}
+@media screen and (max-width: 992px) {
+  .project-list > article {
+    width: 100%;
+    max-width: 100%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+---
+layout: "default"
+description: "Open-source, image related Rust crates."
+---
+
+<div class="project-list">
+{% for project in site.projects %}
+  <article>
+    <h2><a href="{{ project.url }}">{{ project.name }}</a></h2>
+    <p>{{ project.content | markdownify }}</p>
+  </article>
+{% endfor %}
+</div>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,12 @@ description: "Open-source, image related Rust crates."
 ---
 
 <div class="project-list">
-{% for project in site.projects %}
+{% assign sorted_projects = site.projects | sort: "weight" | reverse %}
+{% for project in sorted_projects %}
+  {% assign summary = site.summaries | where: "name",project.name | first %}
   <article>
     <h2><a href="{{ project.url }}">{{ project.name }}</a></h2>
-    <p>{{ project.content | markdownify }}</p>
+    <p>{{ summary.content }}</p>
   </article>
 {% endfor %}
 </div>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,0 @@
-# The image-rs organization
-
-Open-source, image related Rust crates since 2019¹.
-
-¹: split from Piston in 2019, many crates are older.


### PR DESCRIPTION
Mainly intended to give some initial structure and basis for further development. The 
sekeleton files for `image, as well as new files for the other projects, are to be filled in
future pull requests.

The style is oriented around the bare `slate` theme but adjusted to handle the multi
column content and presentation rather than the article content it is optimized for by
default. Specifically, the width of the main content frame has been increased by roughly 
50% as we do not stick to text lines by default. Keeping the same width on project
pages not only keeps the style consistent between this transition but also nudges
page creators to provide more than single-column text presentations, hopefully.

Some links that are also provided in the repository can be inserted into project 
pages by the layout, by setting some appropriate attributes. The summary on the
main page is in its own category to leverage the rendering capabilities of Jekyll,
as page attributes and excerpts are presented as raw text (which could be *either* 
html-ified or markdown-ified), but page creators may want to choose between
markdown and html. The link is created through a shared `name` attribute. Projects
are ordered on the frontpage with a `weight` attribute, where the default value of no
attribute makes the project appear last. This is currently intended to roughly equal to
Github stars, may change *if* we find a better ordering.
